### PR TITLE
Add support for compiler hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "bacon-ls"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "ansi-regex",
  "argh",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap",
  "serde",
@@ -1202,9 +1202,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacon-ls"
-version = "0.13.0"
+version = "0.14.0-dev"
 edition = "2021"
 authors = ["Matteo Bigoi <bigo@crisidev.org>"]
 description = "Bacon Language Server"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bacon Language Server",
   "description": "Rust diagnostic based on Bacon",
   "publisher": "MatteoBigoi",
-  "version": "0.13.0",
+  "version": "0.13.0-dev",
   "private": true,
   "icon": "img/icon.png",
   "repository": {


### PR DESCRIPTION
The compiler rendered message is pushed as a separated hint message which usually shows hints on what can change give the error