### PR TITLE
VSCode: register correct command name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commands": [
       {
         "category": "BaconLs",
-        "command": "bacon_ls.restart",
+        "command": "bacon-ls.restart",
         "title": "Restart"
       }
     ],


### PR DESCRIPTION
`bacon-ls.restart` is the command name registered in `extension.ts`, not `bacon_ls.restart`.

Trying to run the command as it is currently written results in an error:
![image](https://github.com/user-attachments/assets/3929f3a0-f269-4f9a-aeac-0793e9401e39)
