### PR TITLE
Make sure we abort the sync file task

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ struct State {
     diagnostics_data_supported: bool,
     open_files: HashSet<Url>,
     cancel_token: CancellationToken,
+    sync_files_handle: Option<JoinHandle<()>>,
 }
 
 impl Default for State {
@@ -69,6 +70,7 @@ impl Default for State {
             diagnostics_data_supported: false,
             open_files: HashSet::new(),
             cancel_token: CancellationToken::new(),
+            sync_files_handle: None,
         }
     }
 }


### PR DESCRIPTION
@Leandros I implemented the task abort, but without checking if the graceful shutdown works fine (ie no timeout). It seems to be working fine on my setup. I'll merge this and release a new version. 

If we see this doesn't work well, I'll find some time to work on a timeout.