### PR TITLE
Fix tests on Windows

### DIFF
--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -338,7 +338,7 @@ impl Bacon {
 
         if let Some(workspace_folders) = workspace_folders {
             for folder in workspace_folders.iter() {
-                let mut folder_path = folder.uri.to_file_path().unwrap();
+                let mut folder_path = folder.uri.to_file_path().expect("the workspace folder sent by the editor is not a file path");
                 if let Some(git_root) = BaconLs::find_git_root_directory(&folder_path).await {
                     tracing::debug!(
                         "found git root directory {}, using it for files base path",

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -339,7 +339,7 @@ impl Bacon {
 
         if let Some(workspace_folders) = workspace_folders {
             for folder in workspace_folders.iter() {
-                let mut folder_path = PathBuf::from(folder.uri.path());
+                let mut folder_path = folder.uri.to_file_path().unwrap();
                 if let Some(git_root) = BaconLs::find_git_root_directory(&folder_path).await {
                     tracing::debug!(
                         "found git root directory {}, using it for files base path",

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -338,7 +338,10 @@ impl Bacon {
 
         if let Some(workspace_folders) = workspace_folders {
             for folder in workspace_folders.iter() {
-                let mut folder_path = folder.uri.to_file_path().expect("the workspace folder sent by the editor is not a file path");
+                let mut folder_path = folder
+                    .uri
+                    .to_file_path()
+                    .expect("the workspace folder sent by the editor is not a file path");
                 if let Some(git_root) = BaconLs::find_git_root_directory(&folder_path).await {
                     tracing::debug!(
                         "found git root directory {}, using it for files base path",

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -637,7 +637,7 @@ mod tests {
     #[tokio::test]
     async fn test_run_in_background() {
         let cancel_token = CancellationToken::new();
-        let handle = Bacon::run_in_background("echo", "I am running", None, cancel_token.clone()).await;
+        let handle = Bacon::run_in_background("cargo", "--version", None, cancel_token.clone()).await;
         assert!(handle.is_ok());
         cancel_token.cancel();
         handle.unwrap().await.unwrap();

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -746,10 +746,6 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
         assert_eq!(diagnostics[3].1.message.len(), 766);
     }
 
-    // TODO: I need a windows machine to understand why this test fails. I am pretty sure it's
-    // because of how the Url is handled in Windows compared to *NIX, but until I don't have a
-    // proper test bed Windows support is probably broken.
-    #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn test_bacon_diagnostics_production_and_deduplication() {
         let tmp_dir = TempDir::new().unwrap();

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -15,7 +15,6 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_lsp::Client;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url, WorkspaceFolder};
-use tracing::info;
 
 use crate::{BaconLs, DiagnosticData, LOCATIONS_FILE, PKG_NAME, State};
 


### PR DESCRIPTION
This pull request fixes failing tests on Windows, possibly resolving #10. It is not intended to represent a comprehensive review of the code or functionality on Windows, but it does fix the bug that was causing certain tests to fail. The problem was fixed by using `folder.uri.to_file_path().unwrap()` instead of `PathBuf::from(folder.uri.path())` in the `diagnostics` method. The `.to_file_path()` method handles Windows paths correctly, but the `.unwrap()` introduces the possibility of a panic if `diagnostics` is ever called with a non-`file` URL. It should probably use a sensible default instead, or at least pass the error in its return value.

A few other changes in this pull request include the removal of an unused import, swapping `cargo --version` into the background test so that test doesn't fail in PowerShell environments, and enabling a test that was previously disabled on Windows.