### PR TITLE
Add progress for `cargo` backend using LSP `$/progress`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "pretty_assertions",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -375,7 +376,7 @@ dependencies = [
  "os_info",
  "pasetors",
  "pathdiff",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rusqlite",
  "rustc-hash",
@@ -692,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -868,7 +869,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -942,7 +943,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1975,7 +1976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2220,7 +2221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2810,7 +2811,7 @@ dependencies = [
  "getrandom 0.3.1",
  "orion",
  "p384",
- "rand_core",
+ "rand_core 0.6.4",
  "regex",
  "serde",
  "serde_json",
@@ -2973,8 +2974,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2984,7 +2995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2997,12 +3018,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3373,7 +3403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,28 +170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-trait"
-version = "0.1.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,7 +209,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "tower-lsp",
+ "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
 ]
@@ -747,11 +725,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -2843,26 +2822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,14 +3698,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -3752,12 +3717,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
-source = "git+https://github.com/Leandros/tower-lsp.git?rev=1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3#1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3"
+name = "tower-lsp-server"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
@@ -3769,18 +3733,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-lsp-macros",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "git+https://github.com/Leandros/tower-lsp.git?rev=1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3#1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,15 +2510,15 @@ checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -3715,8 +3724,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 [[package]]
 name = "tower-lsp"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+source = "git+https://github.com/Leandros/tower-lsp.git?rev=1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3#1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3738,8 +3746,7 @@ dependencies = [
 [[package]]
 name = "tower-lsp-macros"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+source = "git+https://github.com/Leandros/tower-lsp.git?rev=1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3#1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3884,7 +3891,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.44.1", features = [
 ] }
 tokio-util = "0.7.14"
 toml = "0.8"
-tower-lsp = { git = "https://github.com/Leandros/tower-lsp.git", rev = "1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3" }
+tower-lsp-server = "0.21.1"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [
     "env-filter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
     "env-filter",
     "fmt",
 ] }
+rand = "0.9.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.44.1", features = [
 ] }
 tokio-util = "0.7.14"
 toml = "0.8"
-tower-lsp = "0.20.0"
+tower-lsp = { git = "https://github.com/Leandros/tower-lsp.git", rev = "1d8b5d74424183b0b6cdfaf7ad5cc6ca5b113cc3" }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [
     "env-filter",

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -689,6 +689,7 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn test_bacon_multiline_diagnostics_production() {
         let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join(".bacon-locations");
@@ -751,6 +752,7 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn test_bacon_diagnostics_production_and_deduplication() {
         let tmp_dir = TempDir::new().unwrap();
         let file_path = tmp_dir.path().join(".bacon-locations");

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, fs};
 
-use notify_debouncer_full::{new_debouncer, DebounceEventResult};
+use notify_debouncer_full::{DebounceEventResult, new_debouncer};
 use serde::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -13,10 +13,10 @@ use tokio::process::Command;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri, WorkspaceFolder};
 use tower_lsp::Client;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri, WorkspaceFolder};
 
-use crate::{BaconLs, DiagnosticData, State, LOCATIONS_FILE, PKG_NAME};
+use crate::{BaconLs, DiagnosticData, LOCATIONS_FILE, PKG_NAME, State};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct BaconConfig {
@@ -599,9 +599,11 @@ mod tests {
             path = "{LOCATIONS_FILE}"
         "#
         );
-        assert!(Bacon::validate_preferences_impl(valid_toml.as_bytes(), false)
-            .await
-            .is_ok());
+        assert!(
+            Bacon::validate_preferences_impl(valid_toml.as_bytes(), false)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -730,7 +732,7 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
 
         let workspace_folders = Some(vec![WorkspaceFolder {
             name: tmp_dir.path().display().to_string(),
-            uri: str::parse::<Uri>(format!("file://{}", tmp_dir.path().display())).unwrap(),
+            uri: str::parse::<Uri>(&format!("file://{}", tmp_dir.path().display())).unwrap(),
         }]);
         let diagnostics = Bacon::diagnostics(&error_path_url, LOCATIONS_FILE, workspace_folders.as_deref()).await;
         assert_eq!(diagnostics.len(), 4);
@@ -775,7 +777,7 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
 
         let workspace_folders = Some(vec![WorkspaceFolder {
             name: tmp_dir.path().display().to_string(),
-            uri: str::parse::<Uri>(format!("file://{}", tmp_dir.path().display())).unwrap(),
+            uri: str::parse::<Uri>(&format!("file://{}", tmp_dir.path().display())).unwrap(),
         }]);
         let diagnostics = Bacon::diagnostics(&error_path_url, LOCATIONS_FILE, workspace_folders.as_deref()).await;
         assert_eq!(diagnostics.len(), 3);

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -13,8 +13,8 @@ use tokio::process::Command;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tower_lsp::Client;
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri, WorkspaceFolder};
+use tower_lsp_server::Client;
+use tower_lsp_server::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri, WorkspaceFolder};
 
 use crate::{BaconLs, DiagnosticData, LOCATIONS_FILE, PKG_NAME, State};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tower_lsp::lsp_types::ProgressToken;
-use tower_lsp::{
+use tower_lsp_server::lsp_types::ProgressToken;
+use tower_lsp_server::{
     Client, LspService, Server,
     lsp_types::{Uri, WorkspaceFolder},
 };

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, env, time::Duration};
 
 use tokio::{fs, time::Instant};
 use tower_lsp::{
-    jsonrpc,
+    LanguageServer, jsonrpc,
     lsp_types::{
         CodeAction, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
         CodeActionProviderCapability, CodeActionResponse, DeleteFilesParams, DidChangeTextDocumentParams,
@@ -11,10 +11,9 @@ use tower_lsp::{
         RenameFilesParams, ServerCapabilities, ServerInfo, TextDocumentClientCapabilities, TextDocumentSyncCapability,
         TextDocumentSyncKind, TextEdit, Uri, WorkDoneProgressOptions, WorkspaceEdit,
     },
-    LanguageServer,
 };
 
-use crate::{bacon::Bacon, Backend, BaconLs, Cargo, DiagnosticData, PKG_NAME, PKG_VERSION};
+use crate::{Backend, BaconLs, Cargo, DiagnosticData, PKG_NAME, PKG_VERSION, bacon::Bacon};
 
 #[tower_lsp::async_trait]
 impl LanguageServer for BaconLs {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, env, time::Duration};
 
 use tokio::{fs, time::Instant};
-use tower_lsp::{
+use tower_lsp_server::{
     LanguageServer, jsonrpc,
     lsp_types::{
         CodeAction, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
@@ -15,7 +15,6 @@ use tower_lsp::{
 
 use crate::{Backend, BaconLs, Cargo, DiagnosticData, PKG_NAME, PKG_VERSION, bacon::Bacon};
 
-#[tower_lsp::async_trait]
 impl LanguageServer for BaconLs {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         tracing::info!("initializing {PKG_NAME} v{PKG_VERSION}",);

--- a/src/native.rs
+++ b/src/native.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::{Deserialize, Deserializer};
 use tokio::{fs, process::Command};
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri};
 
 use crate::{DiagnosticData, PKG_NAME};
 
@@ -30,7 +30,7 @@ enum CargoLevel {
 #[derive(Debug, Deserialize)]
 struct CargoSpan {
     #[serde(deserialize_with = "deserialize_url")]
-    file_name: Url,
+    file_name: Uri,
     line_start: u32,
     line_end: u32,
     column_start: u32,
@@ -38,12 +38,12 @@ struct CargoSpan {
     suggested_replacement: Option<String>,
 }
 
-fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+fn deserialize_url<'de, D>(deserializer: D) -> Result<Uri, D::Error>
 where
     D: Deserializer<'de>,
 {
     let url_str: &str = Deserialize::deserialize(deserializer)?;
-    Url::parse(&format!("file://{url_str}")).map_err(serde::de::Error::custom)
+    str::parse::<Uri>(&format!("file://{url_str}")).map_err(serde::de::Error::custom)
 }
 
 #[derive(Debug, Deserialize)]
@@ -86,9 +86,9 @@ impl Cargo {
         severity: &str,
         message: &str,
         span: &CargoSpan,
-        diagnostics: &mut HashMap<Url, Vec<Diagnostic>>,
+        diagnostics: &mut HashMap<Uri, Vec<Diagnostic>>,
     ) -> Result<(), Box<dyn Error>> {
-        if let Some(host) = span.file_name.host().as_ref() {
+        if let Some(host) = span.file_name.authority().map(|auth| auth.host()) {
             let data = span.suggested_replacement.as_ref().map(|replacement| {
                 serde_json::json!(DiagnosticData {
                     corrections: vec![replacement.into()]
@@ -96,8 +96,8 @@ impl Cargo {
             });
             let file_name = current_dir
                 .join(host.to_string())
-                .join(span.file_name.path().replacen("/", "", 1));
-            let url = Url::parse(&format!("file://{}", file_name.display()))?;
+                .join(span.file_name.path().as_str().replacen("/", "", 1));
+            let url = str::parse::<Uri>(&format!("file://{}", file_name.display()))?;
             let diagnostics: &mut Vec<Diagnostic> = diagnostics.entry(url).or_default();
             let diagnostic = Diagnostic {
                 range: Range::new(
@@ -125,7 +125,7 @@ impl Cargo {
         command_args: &str,
         cargo_env: &[String],
         destination_folder: &Path,
-    ) -> Result<HashMap<Url, Vec<Diagnostic>>, Box<dyn Error>> {
+    ) -> Result<HashMap<Uri, Vec<Diagnostic>>, Box<dyn Error>> {
         let mut args: Vec<&str> = command_args.split_whitespace().collect();
         args.push("--manifest-path");
         let cargo_toml = destination_folder.join("Cargo.toml").display().to_string();

--- a/src/native.rs
+++ b/src/native.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::{Deserialize, Deserializer};
 use tokio::{fs, process::Command};
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri};
+use tower_lsp_server::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Uri};
 
 use crate::{DiagnosticData, PKG_NAME};
 


### PR DESCRIPTION
See bottom right corner for the reported progress.

This gives users a little bit of hints whether `cargo check`/`cargo clippy` is currently being executed.


https://github.com/user-attachments/assets/7ff320a6-3599-47e7-98c5-b8ba2e50f443

