### PR TITLE
feat: allow configuring bacon command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ supports the following values:
 - `validateBaconPreferences`: Try to validate that `bacon` preferences are setup correctly to work with `bacon-ls` (default: true).
 - `createBaconPreferencesFile`: If no `bacon` preferences file is found, create a new preferences file with the `bacon-ls` job definition (default: true).
 - `runBaconInBackground`: Run `bacon` in background for the `bacon-ls` job (default: true)
+- `runBaconInBackgroundCommand`: Path to the command used to run `bacon` in the background (defaults to find in `$PATH`).
 - `runBaconInBackgroundCommandArguments`: Command line arguments to pass to `bacon` running in background (default "--headless -j bacon-ls")
 - `synchronizeAllOpenFilesWaitMillis`: How many milliseconds to wait between background diagnostics check to synchronize all open files (default: 2000).
 

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -261,8 +261,8 @@ impl Bacon {
         }
     }
 
-    pub(crate) async fn validate_preferences(create_prefs_file: bool) -> Result<(), String> {
-        let bacon_prefs = Command::new("bacon")
+    pub(crate) async fn validate_preferences(bacon_command: &str, create_prefs_file: bool) -> Result<(), String> {
+        let bacon_prefs = Command::new(bacon_command)
             .arg("--prefs")
             .output()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod native;
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LOCATIONS_FILE: &str = ".bacon-locations";
+const BACON_BACKGROUND_COMMAND: &str = "bacon";
 const BACON_BACKGROUND_COMMAND_ARGS: &str = "--headless -j bacon-ls";
 const CARGO_COMMAND_ARGS: &str =
     "clippy --tests --all-features --all-targets --message-format json-diagnostic-rendered-ansi";
@@ -57,6 +58,7 @@ struct State {
     update_on_change_cooldown_millis: Duration,
     validate_bacon_preferences: bool,
     run_bacon_in_background: bool,
+    run_bacon_in_background_command: String,
     run_bacon_in_background_command_args: String,
     create_bacon_preferences_file: bool,
     bacon_command_handle: Option<JoinHandle<()>>,
@@ -85,6 +87,7 @@ impl Default for State {
             update_on_change_cooldown_millis: Duration::from_millis(5000),
             validate_bacon_preferences: true,
             run_bacon_in_background: true,
+            run_bacon_in_background_command: BACON_BACKGROUND_COMMAND.to_string(),
             run_bacon_in_background_command_args: BACON_BACKGROUND_COMMAND_ARGS.to_string(),
             create_bacon_preferences_file: true,
             bacon_command_handle: None,


### PR DESCRIPTION
A new configuration option, `runBaconInBackgroundCommand`, which allows users to specify the path to the command used to run `bacon` in the background. Previously, the path was hardcoded.  This change enhances flexibility and allows users to specify alternative `bacon` installations or custom commands.

I've been using this feature to debug `bacon-ls` and install `bacon` without polluting my `$PATH`.
