### PR TITLE
fix: reformat bacon preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,22 @@ To find where the file should be saved, you can use the command `bacon --prefs`:
 
 ```toml
 [jobs.bacon-ls]
-command = [ "cargo", "clippy", "--workspace", "--tests", "--all-targets", "--all-features", "--message-format", "json-diagnostic-rendered-ansi" ]
+command = [
+  "cargo", "clippy",
+  "--workspace", "--all-targets", "--all-features",
+  "--message-format", "json-diagnostic-rendered-ansi",
+]
 analyzer = "cargo_json"
 need_stdout = true
 
 [exports.cargo-json-spans]
 auto = true
 exporter = "analyzer"
-line_format = "{diagnostic.level}|:|{span.file_name}|:|{span.line_start}|:|{span.line_end}|:|{span.column_start}|:|{span.column_end}|:|{diagnostic.message}|:|{diagnostic.rendered}|:|{span.suggested_replacement}"
+line_format = """\
+  {diagnostic.level}|:|{span.file_name}|:|{span.line_start}|:|{span.line_end}|:|\
+  {span.column_start}|:|{span.column_end}|:|{diagnostic.message}|:|{diagnostic.rendered}|:|\
+  {span.suggested_replacement}\
+"""
 path = ".bacon-locations"
 ```
 


### PR DESCRIPTION
Make the embedded toml lines shorter, both to fit better in the readme and to make the code more readable. The `--tests` flag was also removed from `command` because it is redundant with `--all-targets`.

I organized the `command` items to be grouped roughly, but I can change to have one item per line if you'd prefer. `line_format` I kept under 100 character line width to hopefully avoid the side scroll box in the Github readme on most monitors, but again if you prefer a different width I can change it.