### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1745377448,
-        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "lastModified": 1764138170,
+        "narHash": "sha256-2bCmfCUZyi2yj9FFXYKwsDiaZmizN75cLhI/eWmf3tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "rev": "bb813de6d2241bcb1b5af2d3059f560c66329967",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This updates nixpkgs to a version that has a supported compiler for bacon-ls dependencies.
The rust compiler in the pinned nixpkgs prior to this PR will not build with the project dependencies when attempting to import bacon-ls as a nix flake:
```
error: Cannot build '/nix/store/93nw9w2sjy2ypbbffd67fj6zrbpwblzz-bacon-ls-deps-0.23.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/1rcmhjb61j757mij6zqsml2yimgrffrh-bacon-ls-deps-0.23.0
       Last 25 log lines:
       > [naersk] cargo_build_options: $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format
       > [naersk] cargo_test_options: $cargo_release -j "$NIX_BUILD_CORES"
       > [naersk] RUST_TEST_THREADS: 10
       > [naersk] cargo_bins_jq_filter: .
       > [naersk] cargo_build_output_json (created): /nix/var/nix/builds/nix-16563-2916811885/tmp.MhPYITScrk
       > [naersk] RUSTFLAGS:
       > [naersk] CARGO_BUILD_RUSTFLAGS:
       > [naersk] CARGO_BUILD_RUSTFLAGS (updated):  --remap-path-prefix /nix/store/b1j95b7qf43znsz4yr9ls8rh4xsqqh28-crates-io-dependencies=/sources --remap-path-prefix /nix/store/hh225lz9rgl80fqld479csfxlfm4zk36-git-dependencies=/sources
       > Running phase: buildPhase
       > cargo build $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format
       > warning: `/nix/var/nix/builds/nix-16563-2916811885/dummy-src/.cargo/config` is deprecated in favor of `config.toml`
       > note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
       > error: rustc 1.86.0 is not supported by the following packages:
       >   cargo@0.92.0 requires rustc 1.89
       >   cargo@0.92.0 requires rustc 1.89
       >   cargo@0.92.0 requires rustc 1.89
       >   cargo-credential-macos-keychain@0.4.17 requires rustc 1.89
       >   cargo-util@0.2.24 requires rustc 1.89
       >   cargo-util-schemas@0.10.1 requires rustc 1.89
       >   crates-io@0.40.14 requires rustc 1.89
       > Either upgrade rustc or select compatible dependency versions with
       > `cargo update <name>@<current-ver> --precise <compatible-ver>`
       > where `<compatible-ver>` is the latest version supporting rustc 1.86.0
       >
       > [naersk] cargo returned with exit code 101, exiting
       For full logs, run:
         nix log /nix/store/93nw9w2sjy2ypbbffd67fj6zrbpwblzz-bacon-ls-deps-0.23.0.drv
error: Cannot build '/nix/store/vy2v6a32jhb2fhmv5awqqh1fyck0hz4l-bacon-ls-0.23.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/2g8aqan150vyzr8q3k764r75rxasy1s3-bacon-ls-0.23.0
```