### PR TITLE
fix: use project_root instead of current_dir to write diagnostics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ impl BaconLs {
         let backend = guard.backend;
         let command_args = guard.cargo_command_args.clone();
         let cargo_env = guard.cargo_env.clone();
+        let project_root = guard.project_root.clone();
         let build_folder = guard.build_folder.clone();
         guard.diagnostics_version += 1;
         let version = guard.diagnostics_version;
@@ -210,10 +211,11 @@ impl BaconLs {
                         .with_percentage(0)
                         .begin()
                         .await;
-                    let diagnostics = Cargo::cargo_diagnostics(&command_args, &cargo_env, &build_folder)
-                        .await
-                        .inspect_err(|err| tracing::error!(?err, "error building diagnostics"))
-                        .unwrap_or_default();
+                    let diagnostics =
+                        Cargo::cargo_diagnostics(&command_args, &cargo_env, project_root.as_ref(), &build_folder)
+                            .await
+                            .inspect_err(|err| tracing::error!(?err, "error building diagnostics"))
+                            .unwrap_or_default();
                     progress.report(90).await;
                     if !diagnostics.contains_key(uri) {
                         tracing::info!(

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -186,6 +186,7 @@ impl LanguageServer for BaconLs {
     async fn initialized(&self, _: InitializedParams) {
         let state = self.state.read().await;
         let proj_root = state.project_root.clone();
+        let build_folder = state.build_folder.clone();
         let run_bacon = state.run_bacon_in_background;
         let bacon_command = state.run_bacon_in_background_command.clone();
         let bacon_command_args = state.run_bacon_in_background_command_args.clone();
@@ -226,7 +227,9 @@ impl LanguageServer for BaconLs {
                             "building the first clean copy of this repo can take while",
                         )
                         .await;
-                    let _ = Cargo::cargo_diagnostics(&cargo_command_args, &cargo_env, &temporary_folder).await;
+                    let _ =
+                        Cargo::cargo_diagnostics(&cargo_command_args, &cargo_env, proj_root.as_ref(), &build_folder)
+                            .await;
                 }
             }
             if validate_prefs {


### PR DESCRIPTION
Resolves https://github.com/crisidev/bacon-ls/issues/86

In this PR, we use `State::project_root` to handle Cargo diagnostics. Previously, we had used `current_dir`, but we found a case in which the `current_dir` is not the same as `State::project_root`, as described in #86. So, using `State::project_root` is more accurate.
If the `State::project_root` is None for some reason, we use the current dir.

I didn't add tests because the current `native.rs` doesn't have tests yet, and writing proper tests might require a bit of refactoring. So, I manually tested this change in my local.