### PR TITLE
Add missing struct field to InitializeResult

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -178,6 +178,7 @@ impl LanguageServer for BaconLs {
                 name: PKG_NAME.to_string(),
                 version: Some(PKG_VERSION.to_string()),
             }),
+            offset_encoding: None,
         })
     }
 


### PR DESCRIPTION
Add `offset_encoding: None` to constructed `InitializeResult`. Not sure if this is the intended behavior. Closes #111 