### PR TITLE
harden cargo/bacon backends; fix URI encoding; expand tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bacon-ls.log
 result
 .coverage
 .direnv
+REVIEW.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "ls-types",
  "notify",
  "notify-debouncer-full",
+ "percent-encoding",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ flume = "0.12.0"
 ls-types = "0.0.6"
 notify = "8.2.0"
 notify-debouncer-full = "0.7.0"
+percent-encoding = "2.3.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.50.0", features = [

--- a/src/bacon.rs
+++ b/src/bacon.rs
@@ -17,7 +17,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_lsp_server::Client;
 
-use crate::{BackendRuntime, BaconLs, Correction, DiagnosticData, LOCATIONS_FILE, PKG_NAME, State};
+use crate::{BackendRuntime, BaconLs, Correction, DiagnosticData, LOCATIONS_FILE, PKG_NAME, State, path_to_file_uri};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct BaconConfig {
@@ -161,10 +161,14 @@ impl Bacon {
 
     fn parse_severity(severity_str: &str) -> DiagnosticSeverity {
         match severity_str {
+            "error" => DiagnosticSeverity::ERROR,
             "warning" => DiagnosticSeverity::WARNING,
             "info" | "information" | "note" | "failure-note" => DiagnosticSeverity::INFORMATION,
             "hint" | "help" => DiagnosticSeverity::HINT,
-            _ => DiagnosticSeverity::ERROR,
+            other => {
+                tracing::warn!("unknown bacon severity level {other:?}, defaulting to INFORMATION");
+                DiagnosticSeverity::INFORMATION
+            }
         }
     }
 
@@ -202,7 +206,7 @@ impl Bacon {
             }
         };
 
-        let path = match str::parse::<Uri>(&format!("file://{}", file_path.display())) {
+        let path = match str::parse::<Uri>(&path_to_file_uri(&file_path.display().to_string())) {
             Ok(url) => url,
             Err(e) => {
                 tracing::error!("error parsing file path {}: {}", file_path.display(), e);
@@ -212,8 +216,8 @@ impl Bacon {
 
         let mut message = line_split[6].replace("\\n", "\n").trim_end_matches('\n').to_string();
         let range = Range::new(
-            Position::new(line_start - 1, column_start - 1),
-            Position::new(line_end - 1, column_end - 1),
+            Position::new(line_start.saturating_sub(1), column_start.saturating_sub(1)),
+            Position::new(line_end.saturating_sub(1), column_end.saturating_sub(1)),
         );
         let replacement = line_split[8];
         let data = if replacement != "none" {
@@ -252,7 +256,7 @@ impl Bacon {
     fn deduplicate_diagnostics(path: Uri, uri: &Uri, diagnostic: Diagnostic, diagnostics: &mut Vec<(Uri, Diagnostic)>) {
         if &path == uri
             && !diagnostics.iter().any(|(existing_path, existing_diagnostic)| {
-                existing_path.path().as_str() == path.path().as_str()
+                existing_path == &path
                     && diagnostic.range == existing_diagnostic.range
                     && diagnostic.severity == existing_diagnostic.severity
                     && diagnostic.message == existing_diagnostic.message
@@ -340,10 +344,10 @@ impl Bacon {
 
         if let Some(workspace_folders) = workspace_folders {
             for folder in workspace_folders.iter() {
-                let mut folder_path = folder
-                    .uri
-                    .to_file_path()
-                    .expect("the workspace folder sent by the editor is not a file path");
+                let Some(mut folder_path) = folder.uri.to_file_path() else {
+                    tracing::warn!("skipping workspace folder with non-file URI: {}", folder.uri.as_str());
+                    continue;
+                };
                 if let Some(git_root) = BaconLs::find_git_root_directory(&folder_path).await
                     && git_root.join("Cargo.toml").exists()
                 {
@@ -429,14 +433,14 @@ impl Bacon {
             .collect::<Vec<Diagnostic>>()
     }
 
-    pub(crate) async fn syncronize_diagnostics(state: Arc<RwLock<State>>, client: Arc<Client>) {
+    pub(crate) async fn synchronize_diagnostics(state: Arc<RwLock<State>>, client: Arc<Client>) {
         tracing::info!("starting background task in charge of syncronizing diagnostics for all open files");
         let (tx, rx) = flume::unbounded::<DebounceEventResult>();
 
         let (locations_file, proj_root, wait_time, shutdown_token) = {
             let state = state.read().await;
             let Some(BackendRuntime::Bacon { config, runtime }) = &state.backend else {
-                tracing::error!("syncronize_diagnostics called without bacon backend");
+                tracing::error!("synchronize_diagnostics called without bacon backend");
                 return;
             };
             (
@@ -447,11 +451,22 @@ impl Bacon {
             )
         };
 
-        let mut watcher = new_debouncer(wait_time, None, move |ev: DebounceEventResult| {
+        let mut watcher = match new_debouncer(wait_time, None, move |ev: DebounceEventResult| {
             // Returns an error if all senders are dropped.
             let _res = tx.send(ev);
-        })
-        .expect("failed to create file watcher");
+        }) {
+            Ok(watcher) => watcher,
+            Err(e) => {
+                let msg = format!(
+                    "bacon-ls could not create a file watcher: {e}. \
+                     Diagnostics will still update on save but open-file \
+                     synchronization is disabled."
+                );
+                tracing::error!("{msg}");
+                client.show_message(ls_types::MessageType::WARNING, msg).await;
+                return;
+            }
+        };
 
         let locations_file_path =
             proj_root.map_or_else(|| PathBuf::from(&locations_file), |root| root.join(&locations_file));
@@ -492,11 +507,13 @@ impl Bacon {
                 continue;
             }
 
-            let loop_state = state.read().await;
-            let Some(BackendRuntime::Bacon { runtime, .. }) = &loop_state.backend else {
+            let mut loop_state = state.write().await;
+            let Some(BackendRuntime::Bacon { runtime, .. }) = &mut loop_state.backend else {
                 tracing::error!("backend changed during sync loop");
                 return;
             };
+            runtime.diagnostics_version = runtime.diagnostics_version.wrapping_add(1);
+            let version = runtime.diagnostics_version;
             let open_files = runtime.open_files.clone();
             let workspace_folders = loop_state.workspace_folders.clone();
             drop(loop_state);
@@ -505,7 +522,7 @@ impl Bacon {
                 open_files.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(",")
             );
             for uri in open_files.iter() {
-                Self::publish_diagnostics(&client, uri, &locations_file, workspace_folders.as_deref()).await;
+                Self::publish_diagnostics(&client, uri, &locations_file, workspace_folders.as_deref(), version).await;
             }
         }
     }
@@ -515,10 +532,13 @@ impl Bacon {
         uri: &Uri,
         locations_file_name: &str,
         workspace_folders: Option<&[WorkspaceFolder]>,
+        version: i32,
     ) {
         let diagnostics_vec = Self::diagnostics_vec(uri, locations_file_name, workspace_folders).await;
         tracing::info!("sent {} bacon diagnostics for {uri:?}", diagnostics_vec.len());
-        client.publish_diagnostics(uri.clone(), diagnostics_vec, None).await;
+        client
+            .publish_diagnostics(uri.clone(), diagnostics_vec, Some(version))
+            .await;
     }
 }
 
@@ -800,5 +820,25 @@ error: could not compile `bacon-ls` (lib) due to 1 previous error"#
         let diagnostics_vec =
             Bacon::diagnostics_vec(&error_path_url, LOCATIONS_FILE, workspace_folders.as_deref()).await;
         assert_eq!(diagnostics_vec.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_severity_known_levels() {
+        assert_eq!(Bacon::parse_severity("error"), DiagnosticSeverity::ERROR);
+        assert_eq!(Bacon::parse_severity("warning"), DiagnosticSeverity::WARNING);
+        assert_eq!(Bacon::parse_severity("note"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Bacon::parse_severity("info"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Bacon::parse_severity("information"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Bacon::parse_severity("failure-note"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Bacon::parse_severity("help"), DiagnosticSeverity::HINT);
+        assert_eq!(Bacon::parse_severity("hint"), DiagnosticSeverity::HINT);
+    }
+
+    #[test]
+    fn test_parse_severity_unknown_level_defaults_to_information() {
+        assert_eq!(
+            Bacon::parse_severity("future-rustc-level"),
+            DiagnosticSeverity::INFORMATION
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,14 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use argh::FromArgs;
 use bacon::Bacon;
 use flume::RecvError;
 use ls_types::{Diagnostic, DiagnosticSeverity, MessageType, ProgressToken, Range, Uri, WorkspaceFolder};
 use native::Cargo;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use serde_json::{Map, Value};
 use tokio::sync::{RwLock, RwLockWriteGuard};
 use tokio::task::JoinHandle;
@@ -21,18 +22,40 @@ mod bacon;
 mod lsp;
 mod native;
 
-// Clippy canary — remove once bacon-ls + clippy integration is verified.
-#[allow(dead_code)]
-fn _clippy_canary() -> i32 {
-    let x = 42;
-    return x;
-}
-
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LOCATIONS_FILE: &str = ".bacon-locations";
 const BACON_BACKGROUND_COMMAND: &str = "bacon";
 const BACON_BACKGROUND_COMMAND_ARGS: &str = "--headless -j bacon-ls";
+
+// Characters that must be percent-encoded when putting an OS path into a
+// `file://` URI. We keep `/` unencoded so it continues to split the path into
+// segments (clients expect multi-segment URIs). This covers the reserved URI
+// characters plus a few that break `Uri` parsing in practice (space, `#`,
+// `?`, `%`, `[`/`]`, backslash, etc.).
+const PATH_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b'%');
+
+/// Build a `file://...` URI string from an OS path. Percent-encodes any
+/// characters that would otherwise break URI parsing (spaces, `#`, `?`, `%`,
+/// etc.), while leaving `/` intact so path segments survive.
+pub(crate) fn path_to_file_uri(path: &str) -> String {
+    format!("file://{}", utf8_percent_encode(path, PATH_ENCODE_SET))
+}
 
 /// bacon-ls - https://github.com/crisidev/bacon-ls
 #[derive(Debug, FromArgs)]
@@ -355,6 +378,11 @@ pub(crate) struct CargoRuntime {
     files_with_diags: HashSet<Uri>,
     diagnostics_version: i32,
     build_folder: PathBuf,
+    // Timestamp of the most recent publish_cargo_diagnostics invocation.
+    // Used by did_open to avoid kicking off a redundant run when one was
+    // just triggered (e.g. the initial run from `initialized` immediately
+    // followed by the client's first `didOpen`).
+    last_run_started: Option<Instant>,
 }
 
 impl Default for CargoRuntime {
@@ -365,6 +393,7 @@ impl Default for CargoRuntime {
             files_with_diags: HashSet::new(),
             diagnostics_version: 0,
             build_folder: PathBuf::new(),
+            last_run_started: None,
         }
     }
 }
@@ -376,6 +405,9 @@ pub(crate) struct BaconRuntime {
     // Some(..) if we have to run bacon in the background ourselves
     pub(crate) command_handle: Option<JoinHandle<()>>,
     pub(crate) sync_files_handle: JoinHandle<()>,
+    // Monotonic counter stamped onto each publishDiagnostics call so clients
+    // can discard stale results if publishes arrive out of order.
+    pub(crate) diagnostics_version: i32,
 }
 
 #[derive(Debug, Default)]
@@ -450,24 +482,34 @@ impl BaconLs {
     fn configure_tracing(log_level: Option<String>) {
         // Configure logging to file.
         let level = log_level.unwrap_or_else(|| env::var("RUST_LOG").unwrap_or("off".to_string()));
-        if level != "off" {
-            tracing_subscriber::fmt()
-                .with_env_filter(level)
-                .with_writer(
-                    std::fs::OpenOptions::new()
-                        .create(true)
-                        .write(true)
-                        .truncate(true)
-                        .open(format!("{PKG_NAME}.log"))
-                        .unwrap(),
-                )
-                .with_thread_names(true)
-                .with_span_events(FmtSpan::CLOSE)
-                .with_target(true)
-                .with_file(true)
-                .with_line_number(true)
-                .init();
+        if level == "off" {
+            return;
         }
+        let log_path = format!("{PKG_NAME}.log");
+        let file = match std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&log_path)
+        {
+            Ok(file) => file,
+            Err(e) => {
+                // stdin/stdout are the LSP jsonrpc pipes; stderr is usually
+                // captured by the client's trace window. One line there is the
+                // best we can do to tell the user why logging is silent.
+                eprintln!("{PKG_NAME}: could not open log file {log_path}: {e} (tracing disabled)");
+                return;
+            }
+        };
+        tracing_subscriber::fmt()
+            .with_env_filter(level)
+            .with_writer(file)
+            .with_thread_names(true)
+            .with_span_events(FmtSpan::CLOSE)
+            .with_target(true)
+            .with_file(true)
+            .with_line_number(true)
+            .init();
     }
 
     /// Run the LSP server.
@@ -640,10 +682,11 @@ impl BaconLs {
                             shutdown_token,
                             open_files: HashSet::new(),
                             command_handle,
-                            sync_files_handle: tokio::task::spawn(Self::syncronize_diagnostics(
+                            sync_files_handle: tokio::task::spawn(Self::synchronize_diagnostics(
                                 task_state,
                                 task_client,
                             )),
+                            diagnostics_version: 0,
                         },
                     });
                     tracing::info!("bacon backend initialized");
@@ -658,7 +701,12 @@ impl BaconLs {
                             .show_message(MessageType::ERROR, format!("Error in \"cargo\" section: {e}"))
                             .await;
                     }
-                    Self::init_cargo_backend(&mut state, config);
+                    if let Err(e) = Self::init_cargo_backend(&mut state, config) {
+                        tracing::error!("{e}");
+                        drop(state);
+                        self.client.show_message(MessageType::ERROR, e).await;
+                        return;
+                    }
                     drop(state);
                 }
             }
@@ -668,7 +716,14 @@ impl BaconLs {
                 Some(BackendRuntime::Cargo { .. }) => BackendChoice::Cargo,
                 None => unreachable!("backend is Some in this branch"),
             };
-            let desired = Self::detect_backend(values).unwrap_or(current_choice);
+            let desired = match Self::detect_backend(values) {
+                Ok(choice) => choice,
+                Err(err) => {
+                    tracing::error!("invalid backend configuration on reload: {err}");
+                    self.client.show_message(MessageType::ERROR, &err).await;
+                    return;
+                }
+            };
 
             if desired != current_choice {
                 let msg = "Backend cannot be changed while the server is running. \
@@ -712,13 +767,33 @@ impl BaconLs {
         }
     }
 
-    fn init_cargo_backend(state: &mut RwLockWriteGuard<'_, State>, config: CargoOptions) {
-        let mut runtime = CargoRuntime::default();
-        if let Some(root) = &state.project_root {
-            runtime.build_folder = root.clone();
-        }
+    fn init_cargo_backend(state: &mut RwLockWriteGuard<'_, State>, config: CargoOptions) -> Result<(), String> {
+        let build_folder = match &state.project_root {
+            Some(root) => root.clone(),
+            None => match env::current_dir() {
+                Ok(cwd) => {
+                    tracing::warn!(
+                        "no Cargo project root detected; falling back to current working directory: {}",
+                        cwd.display()
+                    );
+                    cwd
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "cargo backend cannot start: no project root detected and current working \
+                         directory is unavailable ({e}). Open a folder containing a Cargo.toml and \
+                         restart the server."
+                    ));
+                }
+            },
+        };
+        let runtime = CargoRuntime {
+            build_folder,
+            ..CargoRuntime::default()
+        };
         tracing::info!(build_folder = ?runtime.build_folder, "cargo backend initialized");
         state.backend = Some(BackendRuntime::Cargo { config, runtime });
+        Ok(())
     }
 
     async fn publish_cargo_diagnostics(&self) {
@@ -740,6 +815,7 @@ impl BaconLs {
         let clear_diagnostics_on_check = config.clear_diagnostics_on_check;
         let build_folder = runtime.build_folder.clone();
         runtime.diagnostics_version += 1;
+        runtime.last_run_started = Some(Instant::now());
         let version = runtime.diagnostics_version;
         let refresh_interval = config.refresh_interval_seconds;
 
@@ -975,17 +1051,26 @@ impl BaconLs {
         let mut guard = self.state.write().await;
         let workspace_folders = guard.workspace_folders.clone();
 
-        let Some(BackendRuntime::Bacon { config, .. }) = &mut guard.backend else {
+        let Some(BackendRuntime::Bacon { config, runtime }) = &mut guard.backend else {
             return;
         };
         tracing::info!(uri = uri.to_string(), "publish bacon diagnostics");
         let locations_file_name = config.locations_file.clone();
+        runtime.diagnostics_version = runtime.diagnostics_version.wrapping_add(1);
+        let version = runtime.diagnostics_version;
         drop(guard);
-        Bacon::publish_diagnostics(&self.client, uri, &locations_file_name, workspace_folders.as_deref()).await;
+        Bacon::publish_diagnostics(
+            &self.client,
+            uri,
+            &locations_file_name,
+            workspace_folders.as_deref(),
+            version,
+        )
+        .await;
     }
 
-    async fn syncronize_diagnostics(state: Arc<RwLock<State>>, client: Arc<Client>) {
-        Bacon::syncronize_diagnostics(state, client).await;
+    async fn synchronize_diagnostics(state: Arc<RwLock<State>>, client: Arc<Client>) {
+        Bacon::synchronize_diagnostics(state, client).await;
     }
 }
 
@@ -996,6 +1081,47 @@ mod tests {
     #[test]
     fn test_can_configure_tracing() {
         BaconLs::configure_tracing(Some("info".to_string()));
+    }
+
+    #[test]
+    fn test_path_to_file_uri_plain_ascii() {
+        let uri = path_to_file_uri("/home/me/src/lib.rs");
+        assert_eq!(uri, "file:///home/me/src/lib.rs");
+        let parsed = uri.parse::<Uri>().expect("must parse as Uri");
+        assert_eq!(parsed.path().as_str(), "/home/me/src/lib.rs");
+    }
+
+    #[test]
+    fn test_path_to_file_uri_escapes_space_and_hash_and_percent() {
+        let uri = path_to_file_uri("/home/me/My Projects/tests#1/file%.rs");
+        assert_eq!(uri, "file:///home/me/My%20Projects/tests%231/file%25.rs");
+        let parsed = uri.parse::<Uri>().expect("must parse as Uri");
+        // Uri preserves the encoded form on the wire; clients are responsible
+        // for decoding. We only need to confirm the parse succeeds.
+        assert_eq!(parsed.path().as_str(), "/home/me/My%20Projects/tests%231/file%25.rs");
+    }
+
+    #[test]
+    fn test_path_to_file_uri_preserves_path_separators() {
+        // The `/` separator must NOT be encoded, or clients can't recognize
+        // segment structure.
+        let uri = path_to_file_uri("/a/b/c");
+        assert_eq!(uri, "file:///a/b/c");
+    }
+
+    #[test]
+    fn test_path_to_file_uri_relative_path_preserves_segments() {
+        // Cargo emits relative paths (e.g. "src/lib.rs") in JSON output. The
+        // current `deserialize_url` hack turns those into URIs with the first
+        // segment as "host" — percent-encoding must not break that.
+        let uri = path_to_file_uri("src/lib.rs");
+        assert_eq!(uri, "file://src/lib.rs");
+        let parsed = uri.parse::<Uri>().expect("must parse as Uri");
+        assert_eq!(
+            parsed.authority().map(|a| a.host().to_string()),
+            Some("src".to_string())
+        );
+        assert_eq!(parsed.path().as_str(), "/lib.rs");
     }
 
     #[test]
@@ -1055,5 +1181,244 @@ mod tests {
     fn test_detect_backend_explicit_overrides_keys() {
         let values: Map<String, Value> = serde_json::from_str(r#"{"backend": "cargo", "bacon": {}}"#).unwrap();
         assert_eq!(BaconLs::detect_backend(&values).unwrap(), BackendChoice::Cargo);
+    }
+
+    #[test]
+    fn test_cargo_options_build_args_default() {
+        let args = CargoOptions::default().build_command_args();
+        assert_eq!(args, vec!["check", "--message-format=json-diagnostic-rendered-ansi"]);
+    }
+
+    #[test]
+    fn test_cargo_options_build_args_with_features() {
+        let opts = CargoOptions {
+            features: vec!["a".into(), "b".into(), "c".into()],
+            ..CargoOptions::default()
+        };
+        let args = opts.build_command_args();
+        assert_eq!(
+            args,
+            vec![
+                "check",
+                "--message-format=json-diagnostic-rendered-ansi",
+                "--features",
+                "a,b,c"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cargo_options_build_args_single_feature() {
+        let opts = CargoOptions {
+            features: vec!["only".into()],
+            ..CargoOptions::default()
+        };
+        let args = opts.build_command_args();
+        assert_eq!(
+            args,
+            vec![
+                "check",
+                "--message-format=json-diagnostic-rendered-ansi",
+                "--features",
+                "only"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cargo_options_build_args_with_package_and_extras() {
+        let opts = CargoOptions {
+            command: "clippy".into(),
+            package: Some("my-crate".into()),
+            extra_command_args: vec!["--workspace".into(), "--all-targets".into()],
+            ..CargoOptions::default()
+        };
+        let args = opts.build_command_args();
+        assert_eq!(
+            args,
+            vec![
+                "clippy",
+                "--message-format=json-diagnostic-rendered-ansi",
+                "-p",
+                "my-crate",
+                "--workspace",
+                "--all-targets",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cargo_options_update_from_json_full_roundtrip() {
+        let mut opts = CargoOptions::default();
+        let json = serde_json::json!({
+            "command": "clippy",
+            "features": ["a", "b"],
+            "package": "pkg",
+            "extraCommandArguments": ["--workspace"],
+            "env": {"RUST_LOG": "trace"},
+            "cancelRunning": false,
+            "refreshIntervalSeconds": 10,
+            "separateChildDiagnostics": true,
+            "checkOnSave": false,
+            "clearDiagnosticsOnCheck": true,
+        });
+        let obj = json.as_object().unwrap();
+        opts.update_from_json_obj(obj).expect("should parse");
+        assert_eq!(opts.command, "clippy");
+        assert_eq!(opts.features, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(opts.package.as_deref(), Some("pkg"));
+        assert_eq!(opts.extra_command_args, vec!["--workspace".to_string()]);
+        assert_eq!(opts.env, vec![("RUST_LOG".into(), "trace".into())]);
+        assert!(matches!(opts.publish_mode, PublishMode::QueueIfRunning));
+        assert_eq!(opts.refresh_interval_seconds, Some(Duration::from_secs(10)));
+        assert_eq!(opts.separate_child_diagnostics, Some(true));
+        assert!(!opts.check_on_save);
+        assert!(opts.clear_diagnostics_on_check);
+    }
+
+    #[test]
+    fn test_cargo_options_update_from_json_refresh_null_means_no_partial() {
+        let mut opts = CargoOptions::default();
+        let json = serde_json::json!({"refreshIntervalSeconds": null});
+        opts.update_from_json_obj(json.as_object().unwrap()).unwrap();
+        assert_eq!(opts.refresh_interval_seconds, None);
+    }
+
+    #[test]
+    fn test_cargo_options_update_from_json_refresh_negative_means_no_partial() {
+        let mut opts = CargoOptions::default();
+        let json = serde_json::json!({"refreshIntervalSeconds": -1});
+        opts.update_from_json_obj(json.as_object().unwrap()).unwrap();
+        assert_eq!(opts.refresh_interval_seconds, None);
+    }
+
+    #[test]
+    fn test_cargo_options_update_from_json_rejects_wrong_type() {
+        let mut opts = CargoOptions::default();
+        let json = serde_json::json!({"command": 42});
+        assert!(opts.update_from_json_obj(json.as_object().unwrap()).is_err());
+    }
+
+    #[test]
+    fn test_cargo_options_update_from_json_partial_leaves_others_unchanged() {
+        let mut opts = CargoOptions {
+            command: "clippy".into(),
+            ..CargoOptions::default()
+        };
+        let json = serde_json::json!({"checkOnSave": false});
+        opts.update_from_json_obj(json.as_object().unwrap()).unwrap();
+        assert_eq!(opts.command, "clippy");
+        assert!(!opts.check_on_save);
+    }
+
+    #[test]
+    fn test_cargo_options_reset_restores_defaults() {
+        let mut opts = CargoOptions {
+            command: "clippy".into(),
+            features: vec!["foo".into()],
+            check_on_save: false,
+            ..CargoOptions::default()
+        };
+        opts.reset();
+        let defaults = CargoOptions::default();
+        assert_eq!(opts.command, defaults.command);
+        assert_eq!(opts.features, defaults.features);
+        assert_eq!(opts.check_on_save, defaults.check_on_save);
+    }
+
+    #[test]
+    fn test_bacon_options_update_from_json_full_roundtrip() {
+        let mut opts = BaconOptions::default();
+        let json = serde_json::json!({
+            "locationsFile": "custom.locations",
+            "runInBackground": false,
+            "runInBackgroundCommand": "/usr/local/bin/bacon",
+            "runInBackgroundCommandArguments": "--headless -j custom",
+            "validatePreferences": false,
+            "createPreferencesFile": false,
+            "synchronizeAllOpenFilesWaitMillis": 500,
+            "updateOnSave": false,
+            "updateOnSaveWaitMillis": 250,
+        });
+        opts.update_from_json_obj(json.as_object().unwrap()).unwrap();
+        assert_eq!(opts.locations_file, "custom.locations");
+        assert!(!opts.run_in_background);
+        assert_eq!(opts.run_in_background_command, "/usr/local/bin/bacon");
+        assert_eq!(opts.run_in_background_command_args, "--headless -j custom");
+        assert!(!opts.validate_preferences);
+        assert!(!opts.create_preferences_file);
+        assert_eq!(opts.synchronize_all_open_files_wait, Duration::from_millis(500));
+        assert!(!opts.update_on_save);
+        assert_eq!(opts.update_on_save_wait, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn test_bacon_options_update_from_json_rejects_wrong_type() {
+        let mut opts = BaconOptions::default();
+        let json = serde_json::json!({"runInBackground": "yes"});
+        assert!(opts.update_from_json_obj(json.as_object().unwrap()).is_err());
+    }
+
+    #[test]
+    fn test_bacon_options_reset_restores_defaults() {
+        let mut opts = BaconOptions {
+            run_in_background: false,
+            locations_file: "foo".into(),
+            ..BaconOptions::default()
+        };
+        opts.reset();
+        let defaults = BaconOptions::default();
+        assert_eq!(opts.run_in_background, defaults.run_in_background);
+        assert_eq!(opts.locations_file, defaults.locations_file);
+    }
+
+    #[test]
+    fn test_correction_from_single_empty_is_remove() {
+        let range = Range::default();
+        let c = Correction::from_single(range, "");
+        assert_eq!(c.label, "Remove");
+        assert_eq!(c.edits.len(), 1);
+        assert_eq!(c.edits[0].new_text, "");
+    }
+
+    #[test]
+    fn test_correction_from_single_nonempty_is_replace() {
+        let range = Range::default();
+        let c = Correction::from_single(range, "foo");
+        assert_eq!(c.label, "Replace with: foo");
+        assert_eq!(c.edits.len(), 1);
+    }
+
+    #[test]
+    fn test_correction_from_multi_all_empty_is_remove() {
+        let edits = vec![
+            CorrectionEdit {
+                range: Range::default(),
+                new_text: "".into(),
+            },
+            CorrectionEdit {
+                range: Range::default(),
+                new_text: "".into(),
+            },
+        ];
+        let c = Correction::from_multi(edits);
+        assert_eq!(c.label, "Remove");
+        assert_eq!(c.edits.len(), 2);
+    }
+
+    #[test]
+    fn test_correction_from_multi_labels_by_first_nonempty() {
+        let edits = vec![
+            CorrectionEdit {
+                range: Range::default(),
+                new_text: "".into(),
+            },
+            CorrectionEdit {
+                range: Range::default(),
+                new_text: "new".into(),
+            },
+        ];
+        let c = Correction::from_multi(edits);
+        assert_eq!(c.label, "Replace with: new");
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -4,10 +4,11 @@ use ls_types::{
     CodeAction, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams, CodeActionProviderCapability,
     CodeActionResponse, DeleteFilesParams, DidChangeConfigurationParams, DidChangeTextDocumentParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, ExecuteCommandOptions,
-    ExecuteCommandParams, InitializeParams, InitializeResult, InitializedParams, LSPAny, MessageType,
-    PositionEncodingKind, PublishDiagnosticsClientCapabilities, RenameFilesParams, ServerCapabilities, ServerInfo,
+    ExecuteCommandParams, FileOperationFilter, FileOperationPattern, FileOperationRegistrationOptions,
+    InitializeParams, InitializeResult, InitializedParams, LSPAny, MessageType, PositionEncodingKind,
+    PublishDiagnosticsClientCapabilities, RenameFilesParams, ServerCapabilities, ServerInfo,
     TextDocumentClientCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri,
-    WorkDoneProgressOptions, WorkspaceEdit,
+    WorkDoneProgressOptions, WorkspaceEdit, WorkspaceFileOperationsServerCapabilities, WorkspaceServerCapabilities,
 };
 use tower_lsp_server::{LanguageServer, jsonrpc};
 
@@ -69,6 +70,22 @@ impl LanguageServer for BaconLs {
         tracing::trace!("loaded state from lsp settings: {state:#?}");
         drop(state);
 
+        // Declare didDelete/didRename so clients actually send those events
+        // (handlers live in this file). The bacon backend tracks open files
+        // and needs these to keep its set in sync when the user renames/deletes
+        // through the file explorer. Cargo backend is unaffected but the
+        // capability is cheap to advertise.
+        let rust_file_filter = FileOperationFilter {
+            scheme: Some("file".to_string()),
+            pattern: FileOperationPattern {
+                glob: "**/*.rs".to_string(),
+                matches: None,
+                options: None,
+            },
+        };
+        let file_ops_registration = FileOperationRegistrationOptions {
+            filters: vec![rust_file_filter],
+        };
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 // Only support UTF-16 positions for now, which is the default when unspecified
@@ -84,6 +101,14 @@ impl LanguageServer for BaconLs {
                 execute_command_provider: Some(ExecuteCommandOptions {
                     commands: vec!["bacon_ls.run".to_string()],
                     ..Default::default()
+                }),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: None,
+                    file_operations: Some(WorkspaceFileOperationsServerCapabilities {
+                        did_rename: Some(file_ops_registration.clone()),
+                        did_delete: Some(file_ops_registration),
+                        ..Default::default()
+                    }),
                 }),
                 ..Default::default()
             },
@@ -106,8 +131,13 @@ impl LanguageServer for BaconLs {
         self.pull_configuration().await;
 
         let mut state = self.state.write().await;
-        if state.backend.is_none() {
-            Self::init_cargo_backend(&mut state, CargoOptions::default());
+        if state.backend.is_none()
+            && let Err(e) = Self::init_cargo_backend(&mut state, CargoOptions::default())
+        {
+            tracing::error!("{e}");
+            drop(state);
+            self.client.show_message(MessageType::ERROR, e).await;
+            return;
         }
         let backend_chosen = state
             .backend
@@ -156,7 +186,17 @@ impl LanguageServer for BaconLs {
                 drop(state);
                 self.publish_bacon_diagnostics(&params.text_document.uri).await;
             }
-            Some(BackendRuntime::Cargo { .. }) => {
+            Some(BackendRuntime::Cargo { runtime, .. }) => {
+                // Debounce against the initial cargo run: on client startup,
+                // `initialized` kicks off a run and the first `didOpen`
+                // arrives in the same flurry. Skipping here lets the in-flight
+                // run complete instead of being cancelled and restarted.
+                if let Some(ts) = runtime.last_run_started
+                    && ts.elapsed() < std::time::Duration::from_secs(1)
+                {
+                    tracing::trace!("did_open within debounce window of last cargo trigger; skipping");
+                    return;
+                }
                 drop(state);
                 self.publish_cargo_diagnostics().await;
             }

--- a/src/native.rs
+++ b/src/native.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 use tokio::process::Command;
 use tower_lsp_server::{Bounded, NotCancellable, OngoingProgress};
 
-use crate::{Correction, CorrectionEdit, DiagnosticData, PKG_NAME};
+use crate::{BaconLs, Correction, CorrectionEdit, DiagnosticData, PKG_NAME, path_to_file_uri};
 
 /// Like `read_until` but stops at either `\r` or `\n`.
 /// Returns the number of bytes read (0 = EOF).
@@ -89,7 +89,7 @@ where
     D: Deserializer<'de>,
 {
     let url_str: &str = Deserialize::deserialize(deserializer)?;
-    str::parse::<Uri>(&format!("file://{url_str}")).map_err(serde::de::Error::custom)
+    str::parse::<Uri>(&path_to_file_uri(url_str)).map_err(serde::de::Error::custom)
 }
 
 #[derive(Debug, Deserialize)]
@@ -143,10 +143,14 @@ fn parse_building_line(line: &str) -> Option<(String, u32)> {
 impl Cargo {
     fn parse_severity(severity_str: &str) -> DiagnosticSeverity {
         match severity_str {
+            "error" => DiagnosticSeverity::ERROR,
             "warning" | "failure-note" => DiagnosticSeverity::WARNING,
             "info" | "information" | "note" => DiagnosticSeverity::INFORMATION,
             "hint" | "help" => DiagnosticSeverity::HINT,
-            _ => DiagnosticSeverity::ERROR,
+            other => {
+                tracing::warn!("unknown cargo severity level {other:?}, defaulting to INFORMATION");
+                DiagnosticSeverity::INFORMATION
+            }
         }
     }
 
@@ -183,7 +187,7 @@ impl Cargo {
             .into_string()
             .map_err(|_orig| std::io::Error::other("cannot convert file name to string"))?;
         Ok(Some(
-            str::parse::<Uri>(&format!("file://{file_name}")).context("parsing filename")?,
+            str::parse::<Uri>(&path_to_file_uri(&file_name)).context("parsing filename")?,
         ))
     }
 
@@ -217,8 +221,11 @@ impl Cargo {
                                     location: Location {
                                         uri,
                                         range: Range::new(
-                                            Position::new(s.line_start - 1, s.column_start - 1),
-                                            Position::new(s.line_end - 1, s.column_end - 1),
+                                            Position::new(
+                                                s.line_start.saturating_sub(1),
+                                                s.column_start.saturating_sub(1),
+                                            ),
+                                            Position::new(s.line_end.saturating_sub(1), s.column_end.saturating_sub(1)),
                                         ),
                                     },
                                     message: child.message.clone(),
@@ -245,8 +252,14 @@ impl Cargo {
             };
             tracing::trace!(uri = url.to_string(), "adding diagnostic");
             let range = Range::new(
-                Position::new(resolved.line_start - 1, resolved.column_start - 1),
-                Position::new(resolved.line_end - 1, resolved.column_end - 1),
+                Position::new(
+                    resolved.line_start.saturating_sub(1),
+                    resolved.column_start.saturating_sub(1),
+                ),
+                Position::new(
+                    resolved.line_end.saturating_sub(1),
+                    resolved.column_end.saturating_sub(1),
+                ),
             );
             let corrections: Vec<Correction> = resolved
                 .is_machine_applicable()
@@ -286,8 +299,14 @@ impl Cargo {
                     continue;
                 };
                 let range = Range::new(
-                    Position::new(resolved.line_start - 1, resolved.column_start - 1),
-                    Position::new(resolved.line_end - 1, resolved.column_end - 1),
+                    Position::new(
+                        resolved.line_start.saturating_sub(1),
+                        resolved.column_start.saturating_sub(1),
+                    ),
+                    Position::new(
+                        resolved.line_end.saturating_sub(1),
+                        resolved.column_end.saturating_sub(1),
+                    ),
                 );
 
                 // Group all MachineApplicable primary spans within this child
@@ -303,8 +322,8 @@ impl Cargo {
                         let r = s.project_span();
                         Some(CorrectionEdit {
                             range: Range::new(
-                                Position::new(r.line_start - 1, r.column_start - 1),
-                                Position::new(r.line_end - 1, r.column_end - 1),
+                                Position::new(r.line_start.saturating_sub(1), r.column_start.saturating_sub(1)),
+                                Position::new(r.line_end.saturating_sub(1), r.column_end.saturating_sub(1)),
                             ),
                             new_text: new_text.to_string(),
                         })
@@ -356,6 +375,10 @@ impl Cargo {
         let mut child = cmd
             .args(command_args)
             .current_dir(destination_folder)
+            // Close stdin explicitly: the LSP server's stdin is the jsonrpc
+            // pipe, and we must not let cargo (or any tool it invokes) inherit
+            // and read from it.
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)
@@ -457,58 +480,42 @@ impl Cargo {
         Ok(())
     }
 
-    pub(crate) async fn find_git_root_directory() -> Option<PathBuf> {
-        let output = tokio::process::Command::new("git")
-            .arg("rev-parse")
-            .arg("--show-toplevel")
-            .output()
-            .await
-            .ok()?;
-
-        if output.status.success() {
-            String::from_utf8(output.stdout).ok().map(|v| PathBuf::from(v.trim()))
-        } else {
-            None
-        }
-    }
-
     pub(crate) async fn find_project_root(params: &InitializeParams) -> Option<PathBuf> {
-        let git_root = Self::find_git_root_directory().await?;
-
-        // We only chose the git root as our workspace root if a
-        // `Cargo.toml` actually exists in the git root.
-        if git_root.join("Cargo.toml").exists() {
-            return Some(git_root);
-        }
-
+        // Build an ordered list of candidate paths to probe:
+        // client-authoritative workspace folders first, then the deprecated
+        // root_uri/root_path fields, then the server's own CWD as a last
+        // resort. This avoids ever picking the LSP server's CWD over an
+        // explicitly-specified workspace folder.
+        let mut candidates: Vec<PathBuf> = Vec::new();
         if let Some(workspace_folders) = &params.workspace_folders {
             for folder in workspace_folders {
-                let root_path = PathBuf::from(folder.uri.path().as_str());
-                if root_path.join("Cargo.toml").exists() {
-                    return Some(root_path);
-                }
+                candidates.push(PathBuf::from(folder.uri.path().as_str()));
             }
         }
-
         #[allow(deprecated)]
         if let Some(root_uri) = &params.root_uri {
-            let root_path = PathBuf::from(root_uri.path().as_str());
-            if root_path.join("Cargo.toml").exists() {
-                return Some(root_path);
-            }
+            candidates.push(PathBuf::from(root_uri.path().as_str()));
         }
-
         #[allow(deprecated)]
         if let Some(root_path) = &params.root_path {
-            let root_path = PathBuf::from(root_path);
-            if root_path.join("Cargo.toml").exists() {
-                return Some(root_path);
-            }
+            candidates.push(PathBuf::from(root_path));
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            candidates.push(cwd);
         }
 
-        let cwd = std::env::current_dir().ok()?;
-        if cwd.join("Cargo.toml").exists() {
-            return Some(cwd);
+        for candidate in &candidates {
+            // Prefer the git root containing this candidate when it has a
+            // Cargo.toml — this lets a nested crate resolve to the workspace
+            // root, which is where cargo needs to run.
+            if let Some(git_root) = BaconLs::find_git_root_directory(candidate).await
+                && git_root.join("Cargo.toml").exists()
+            {
+                return Some(git_root);
+            }
+            if candidate.join("Cargo.toml").exists() {
+                return Some(candidate.clone());
+            }
         }
 
         None
@@ -647,8 +654,14 @@ mod tests {
         assert_eq!(primary_spans[0].suggested_replacement.as_deref(), Some(""));
         let resolved = primary_spans[0].project_span();
         let range = Range::new(
-            Position::new(resolved.line_start - 1, resolved.column_start - 1),
-            Position::new(resolved.line_end - 1, resolved.column_end - 1),
+            Position::new(
+                resolved.line_start.saturating_sub(1),
+                resolved.column_start.saturating_sub(1),
+            ),
+            Position::new(
+                resolved.line_end.saturating_sub(1),
+                resolved.column_end.saturating_sub(1),
+            ),
         );
         let correction = Correction::from_single(range, "");
         assert_eq!(correction.label, "Remove");
@@ -680,8 +693,14 @@ mod tests {
                 let resolved = s.project_span();
                 Some(CorrectionEdit {
                     range: Range::new(
-                        Position::new(resolved.line_start - 1, resolved.column_start - 1),
-                        Position::new(resolved.line_end - 1, resolved.column_end - 1),
+                        Position::new(
+                            resolved.line_start.saturating_sub(1),
+                            resolved.column_start.saturating_sub(1),
+                        ),
+                        Position::new(
+                            resolved.line_end.saturating_sub(1),
+                            resolved.column_end.saturating_sub(1),
+                        ),
                     ),
                     new_text: new_text.to_string(),
                 })
@@ -712,5 +731,61 @@ mod tests {
         let span: CargoSpan = serde_json::from_str(json).unwrap();
         let resolved = span.project_span();
         assert!(std::ptr::eq(resolved, &span));
+    }
+
+    #[test]
+    fn test_parse_building_line_basic() {
+        // The returned message is the portion after "] " (i.e. fraction + crate list),
+        // not the full original line — that's the piece suitable for a progress report.
+        let line = "Building [====       ] 7/10: foo, bar";
+        let (msg, pct) = parse_building_line(line).unwrap();
+        assert_eq!(msg, "7/10: foo, bar");
+        assert_eq!(pct, 70);
+    }
+
+    #[test]
+    fn test_parse_building_line_caps_percentage_at_99() {
+        let line = "Building [========] 10/10: last";
+        let (_, pct) = parse_building_line(line).unwrap();
+        assert_eq!(
+            pct, 99,
+            "100% should cap at 99 to keep the bar indeterminate until Finished"
+        );
+    }
+
+    #[test]
+    fn test_parse_building_line_rejects_non_building_prefix() {
+        assert!(parse_building_line("Finished `dev` profile").is_none());
+        assert!(parse_building_line("Compiling foo v0.1.0").is_none());
+    }
+
+    #[test]
+    fn test_parse_building_line_zero_total_returns_none() {
+        assert!(parse_building_line("Building [] 0/0: nothing").is_none());
+    }
+
+    #[test]
+    fn test_parse_building_line_malformed_returns_none() {
+        assert!(parse_building_line("Building [====] no-fraction-here").is_none());
+        assert!(parse_building_line("Building [====] abc/def: foo").is_none());
+    }
+
+    #[test]
+    fn test_parse_severity_known_levels() {
+        assert_eq!(Cargo::parse_severity("error"), DiagnosticSeverity::ERROR);
+        assert_eq!(Cargo::parse_severity("warning"), DiagnosticSeverity::WARNING);
+        assert_eq!(Cargo::parse_severity("failure-note"), DiagnosticSeverity::WARNING);
+        assert_eq!(Cargo::parse_severity("note"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Cargo::parse_severity("info"), DiagnosticSeverity::INFORMATION);
+        assert_eq!(Cargo::parse_severity("help"), DiagnosticSeverity::HINT);
+        assert_eq!(Cargo::parse_severity("hint"), DiagnosticSeverity::HINT);
+    }
+
+    #[test]
+    fn test_parse_severity_unknown_level_defaults_to_information() {
+        assert_eq!(
+            Cargo::parse_severity("something-brand-new"),
+            DiagnosticSeverity::INFORMATION
+        );
     }
 }


### PR DESCRIPTION
Robustness — replace the panics that could take the LSP server down with graceful degradation + client-visible errors:

- bacon: skip workspace folders whose URI is not file:// (vscode-remote, git:// etc.) with a warn log instead of panicking on to_file_path().
- bacon: watcher creation failure now surfaces as a LSP message and exits the sync loop cleanly; did_save-driven publishing still works.
- lib: log file open failure writes one line to stderr and continues without tracing, instead of .unwrap()'ing at startup in read-only CWDs.
- native: cargo spawned with stdin(Stdio::null()) so it cannot inherit the LSP jsonrpc pipe and steal messages from the client.
- lib: init_cargo_backend now returns Result<(), String>; if no project root is detected it falls back to the current working directory (with a warn) and fails loudly via show_message if even CWD is unavailable.
- lsp: declare workspace.fileOperations with didRename/didDelete registrations on **/*.rs so spec-compliant clients actually invoke the existing rename/delete handlers.

Correctness:

- native/bacon: saturating_sub(1) on all line/column arithmetic so a cargo position of 0 no longer panics in debug / wraps in release.
- native/bacon: parse_severity now maps "error" explicitly and defaults unknown levels to INFORMATION with a warn log, instead of silently treating them as ERROR.
- lsp: did_open debounces against the initialized run via a new CargoRuntime.last_run_started timestamp, so the first did_open no longer cancels the in-flight initial cargo run.
- bacon: publish_diagnostics stamps Some(version) like the cargo backend, giving clients the staleness guard they already had for cargo.
- lib/native: drop Cargo::find_git_root_directory() (which ran in the LSP server's CWD, not the workspace) and consolidate on the path-taking BaconLs::find_git_root_directory(path). find_project_root now probes workspace folders, root_uri, root_path, and CWD in that order — each candidate tried as-is and via git rev-parse.
- lib: adapt_to_settings surfaces detect_backend errors on config reload via show_message instead of silently falling back.
- bacon: deduplicate_diagnostics uses full Uri equality rather than path().as_str() string comparison.

URI encoding:

- lib: introduce path_to_file_uri() with a PATH_ENCODE_SET that percent-encodes space, #, ?, %, [, ], \\, ^, |, {, }, <, >, ", backtick and controls while preserving /. Used from native::span_to_uri, native::deserialize_url, and bacon::parse_bacon_diagnostic_line. Paths with spaces or reserved URI characters now produce valid URIs editors can match to files. Adds percent-encoding = "2.3.2".

Hygiene:

- Rename syncronize_diagnostics → synchronize_diagnostics everywhere.