### PR TITLE
fix(cargo/live): stop aborting in-flight runs; fix stale diagnostics on save/close

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1404,6 +1404,26 @@ impl BaconLs {
         let bacon = self.clone();
         runtime.live_debounce = Some(tokio::spawn(async move {
             tokio::time::sleep(delay).await;
+            // The sleep is over: from here this task IS the live cargo run,
+            // not a pending trigger. Drop our own handle before starting the
+            // run so a later schedule_live_run / cancel_live_debounce can no
+            // longer abort() us mid-run — aborting a running task kills the
+            // cargo child and orphans its progress token (a `begin` with no
+            // `end`), which leaves the client's "checking" status spinning
+            // forever. In-flight runs are instead superseded by the
+            // CancelRunning publish mode, which finishes the token properly.
+            //
+            // The take() is best-effort: if a newer trigger already replaced
+            // our handle (and aborted us) while we held nothing, we die at
+            // this .await before touching anything. If we win the race and
+            // null out a newer handle, the worst case is one extra cargo run
+            // that CancelRunning immediately supersedes — never a leak.
+            {
+                let mut state = bacon.state.write().await;
+                if let Some(BackendRuntime::Cargo { runtime, .. }) = &mut state.backend {
+                    let _ = runtime.live_debounce.take();
+                }
+            }
             bacon.publish_cargo_diagnostics_live().await;
         }));
     }
@@ -1421,27 +1441,37 @@ impl BaconLs {
     }
 
     /// On `did_save` / `did_close`, replace the (possibly dirty) shadow file
-    /// with a fresh hardlink to the on-disk version, and forget the URI.
-    pub(crate) async fn restore_shadow_link_if_dirty(&self, uri: &Uri) {
+    /// with the on-disk version, and forget the URI. `discard` selects the
+    /// did_close semantics: restore by copy (fresh mtime, so cargo actually
+    /// re-checks the reverted content instead of replaying the dirty build's
+    /// cached warnings) rather than by hardlink.
+    /// Returns true when the file actually had a dirty override to restore.
+    pub(crate) async fn restore_shadow_link_if_dirty(&self, uri: &Uri, discard: bool) -> bool {
         let (shadow, real_path) = {
             let mut state = self.state.write().await;
             let Some(BackendRuntime::Cargo { runtime, .. }) = &mut state.backend else {
-                return;
+                return false;
             };
             if !runtime.dirty_files.remove(uri) {
-                return;
+                return false;
             }
             let Some(shadow) = runtime.shadow.clone() else {
-                return;
+                return false;
             };
             let Some(path_cow) = uri.to_file_path() else {
-                return;
+                return false;
             };
             (shadow, path_cow.into_owned())
         };
-        if let Err(e) = shadow.restore_link(&real_path).await {
+        let restored = if discard {
+            shadow.restore_copy(&real_path).await
+        } else {
+            shadow.restore_link(&real_path).await
+        };
+        if let Err(e) = restored {
             tracing::warn!(path = ?real_path, ?e, "updateOnInsert: failed to restore shadow link");
         }
+        true
     }
 
     async fn publish_bacon_diagnostics(&self, uri: &Uri) {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -257,9 +257,32 @@ impl LanguageServer for BaconLs {
         }
         drop(state);
         // Cargo backend with live shadow: revert any dirty buffer for the
-        // closed file back to a hardlink so subsequent live runs read the
-        // on-disk version.
-        self.restore_shadow_link_if_dirty(&params.text_document.uri).await;
+        // closed file back to the on-disk version so subsequent live runs
+        // read it.
+        if self.restore_shadow_link_if_dirty(&params.text_document.uri, true).await {
+            // The file was closed with unchecked in-buffer changes: whatever
+            // diagnostics we last published were computed against content
+            // that no longer exists anywhere (buffer gone, shadow reverted).
+            // Leaving them up shows stale positions — and a client reopening
+            // the file can even crash re-anchoring a now out-of-range line
+            // (observed in Neovim's diagnostic module). Clear them and let a
+            // fresh live run publish the truth for the on-disk content.
+            self.client
+                .publish_diagnostics(params.text_document.uri.clone(), vec![], None)
+                .await;
+            let debounce = {
+                let state = self.state.read().await;
+                match &state.backend {
+                    Some(BackendRuntime::Cargo { config, .. }) if config.update_on_insert => {
+                        Some(config.update_on_insert_debounce)
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(debounce) = debounce {
+                self.schedule_live_run(debounce).await;
+            }
+        }
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
@@ -282,14 +305,23 @@ impl LanguageServer for BaconLs {
                 let check_on_save = config.check_on_save;
                 drop(state);
                 // A pending live run would race with the canonical save run
-                // and publish stale (pre-save) shadow diagnostics on top.
-                // Cancel it before doing anything else.
-                self.cancel_live_debounce().await;
+                // and publish stale (pre-save) shadow diagnostics on top, so
+                // cancel it first — but ONLY when a save run will replace it.
+                // With checkOnSave off, the pending live trigger is the only
+                // check this edit will ever get: a save arriving inside the
+                // debounce window (e.g. an editor's save-on-focus-lost right
+                // after a keystroke) would otherwise silently leave
+                // diagnostics stale. Letting it run is safe — the saved file
+                // has the same content the shadow was already checking.
+                if check_on_save {
+                    self.cancel_live_debounce().await;
+                }
                 // Save makes the shadow's dirty override stale: the on-disk
                 // file now matches what the user wants checked. Restore the
                 // hardlink before the cargo run so the live target dir picks
                 // up the saved content next time it's used.
-                self.restore_shadow_link_if_dirty(&params.text_document.uri).await;
+                self.restore_shadow_link_if_dirty(&params.text_document.uri, false)
+                    .await;
                 if check_on_save {
                     self.publish_cargo_diagnostics().await;
                 }

--- a/src/shadow.rs
+++ b/src/shadow.rs
@@ -104,9 +104,21 @@ impl ShadowWorkspace {
         Ok(())
     }
 
+    /// Restore the shadow entry for `real_path` to a fresh COPY of the
+    /// on-disk content. Used on `did_close` of a dirty buffer: a hardlink
+    /// restore would give the shadow file the real file's (older) mtime,
+    /// making cargo consider the crate fresh and REPLAY the cached warnings
+    /// from the last dirty build instead of re-checking the reverted
+    /// content. A copy gets a now-mtime, forcing a real re-check.
+    pub(crate) async fn restore_copy(&self, real_path: &Path) -> std::io::Result<()> {
+        let content = tokio::fs::read_to_string(real_path).await?;
+        self.write_dirty(real_path, &content).await
+    }
+
     /// Restore the shadow entry for `real_path` back to a hardlink of the
-    /// on-disk file. Used after `did_save` / `did_close` so subsequent cargo
-    /// runs see the saved content.
+    /// on-disk file. Used after `did_save` so subsequent cargo runs see the
+    /// saved content (the just-written mtime keeps cargo's change detection
+    /// correct there — see `restore_copy` for the did_close case).
     pub(crate) async fn restore_link(&self, real_path: &Path) -> std::io::Result<()> {
         let shadow_path = self.shadow_path_for(real_path)?;
         if tokio::fs::try_exists(&shadow_path).await? {
@@ -372,6 +384,31 @@ mod tests {
             "restore_link must hardlink shadow back to the real file"
         );
         assert_eq!(std::fs::read_to_string(&shadow_lib_rs).unwrap(), "saved");
+    }
+
+    #[tokio::test]
+    async fn test_restore_copy_reverts_content_without_hardlinking() {
+        let tmp = TempDir::new().unwrap();
+        mk_file(&tmp.path().join(".gitignore"), "target/\n");
+        let lib_rs = tmp.path().join("src/lib.rs");
+        mk_file(&lib_rs, "saved");
+        let shadow = ShadowWorkspace::build(tmp.path().to_path_buf()).await.unwrap();
+        let shadow_lib_rs = shadow.shadow_root().join("src/lib.rs");
+
+        shadow.write_dirty(&lib_rs, "dirty").await.unwrap();
+        assert_ne!(inode(&lib_rs), inode(&shadow_lib_rs));
+
+        shadow.restore_copy(&lib_rs).await.unwrap();
+        // Content matches the on-disk file again...
+        assert_eq!(std::fs::read_to_string(&shadow_lib_rs).unwrap(), "saved");
+        // ...but it is a distinct inode, not a hardlink: this is what gives
+        // the shadow file a fresh mtime so cargo re-checks instead of
+        // replaying the dirty build's cached diagnostics.
+        assert_ne!(
+            inode(&lib_rs),
+            inode(&shadow_lib_rs),
+            "restore_copy must NOT hardlink (a fresh copy carries a new mtime)"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Three related bugs in the cargo backend's `updateOnInsert` live diagnostics leave the client stuck on a "checking…" progress spinner and/or showing stale results. All three live in the live-run / shadow-workspace lifecycle. I ran into them with a Neovim + auto-save setup where the diagnostics pane would fill with permanent "checking cargo clippy" rows and stop updating.

## The bugs

**1. `abort()` kills in-flight cargo runs, orphaning the progress token.**
`schedule_live_run()` stores the debounce task's `JoinHandle` and `abort()`s it on the next `did_change`; `cancel_live_debounce()` does the same on `did_save`. But that handle keeps referring to the same task *after* its `sleep(debounce)` elapses — and at that point the task is no longer a pending trigger, it's the running cargo check. Aborting it kills the cargo child and drops the `$/progress` token mid-flight: a `begin` with no matching `end`. The editor then shows a "checking" row that never clears, one per interrupted run. With auto-save this is relentless — the `didSave` lands right inside the run the preceding keystroke scheduled, so the *last* run of every typing burst dies and diagnostics never refresh.

*Fix:* once past its sleep, the task drops its own handle before doing any work, so a later `abort()` can only ever cancel a still-sleeping trigger. Genuinely superseded runs are already handled by the `CancelRunning` publish mode, which ends the token cleanly.

**2. `did_save` cancels the only pending check when `checkOnSave` is off.**
With `checkOnSave = false`, the pending live trigger is the *only* check the current edit will get. But `did_save` unconditionally calls `cancel_live_debounce()`, so a save that arrives inside the debounce window (an editor that saves on focus-loss, or right after a keystroke) silently drops the check and diagnostics stay stale until the next edit. Now the cancel only runs when a save-run will actually replace it (`checkOnSave = true`).

**3. Closing a dirty buffer leaves stale diagnostics and replays cached warnings.**
On `did_close` of a buffer with unsaved changes, the last-published diagnostics were computed against buffer content that no longer exists anywhere, yet they stay up. Worse, restoring the shadow file by hardlink gives it the real file's *older* mtime, so the next cargo run treats the crate as fresh and replays the previous dirty build's cached warnings instead of re-checking the reverted content. (Neovim's diagnostic module can also crash re-anchoring the now out-of-range stale diagnostic on reopen.) Now `did_close` of a dirty file clears its diagnostics, restores the shadow entry by **copy** (fresh mtime → real re-check) instead of hardlink, and schedules a live run to publish the truth for the on-disk content.

## Changes
- `src/lib.rs` — debounce task drops its own handle after the sleep; `restore_shadow_link_if_dirty` gains a `discard` flag (copy vs hardlink) and returns whether it did anything.
- `src/lsp.rs` — `did_save` only cancels the live trigger when `checkOnSave`; `did_close` clears + re-checks dirty files.
- `src/shadow.rs` — new `restore_copy` (fresh-mtime restore) alongside `restore_link`, with a unit test.

No new struct fields, so the `large_enum_variant` size of `BackendRuntime` is unchanged.

## Testing
- `cargo test` (124 tests, incl. the new `restore_copy` test), `cargo fmt --all -- --check`, and `cargo clippy --all-targets` all clean — matching CI.
- Verified against a 35-case headless Neovim end-to-end suite (real LSP client, real auto-save): lint/syntax/type errors appearing and clearing on unsaved buffers, cross-crate error propagation in a multi-crate workspace, serde-derive and macro-expansion errors, `Cargo.toml` dependency edits, dirty close/reopen cycles, mid-run cancellation storms, and hostile `didSave` timings — zero leaked progress tokens throughout, and a 120-op randomized soak converged clean with ~9.5 MB RSS and no stray cargo processes.

Happy to split this into separate commits/PRs if you'd prefer to review the three fixes independently — I kept them together because they share the `restore_shadow_link_if_dirty` signature change and were developed and tested as one.
